### PR TITLE
使 Callout 别名支持折叠

### DIFF
--- a/src/ABConverter/ABAlias.ts
+++ b/src/ABConverter/ABAlias.ts
@@ -98,8 +98,8 @@ interface ABAlias_json_item {
 
 // 允许带参数的部分 (这部分的遍历会更耗时间。为了性能考虑，单独拿出来)
 const ABAlias_json_withSub: ABAlias_json_item[] = [
-  { regex: /\|::: 140lne\|(info|note|warning|caution|attention|error|danger|tips|tip|hint|example|abstract|summary|tldr|quote|cite|todo|success|check|done)\s?(.*?)\|/, replacement: "|add([!$1] $2)|quote|" },
-  { regex: /\|quote (\S+)\s?(.*)\|/, replacement: "|add([!$1] $2)|quote|" }, // 注意避免和callout语法冲突，以及自身递归
+  { regex: /\|::: 140lne\|(info|note|warning|caution|attention|error|danger|tips|tip|hint|example|abstract|summary|tldr|quote|cite|todo|success|check|done)([+-]?)\s?(.*?)\|/, replacement: "|add([!$1]$2 $3)|quote|" },
+  { regex: /\|quote (\S+)([+-]?)\s?(.*)\|/, replacement: "|add([!$1]$2 $3)|quote|" }, // 注意避免和callout语法冲突，以及自身递归
 ]
 
 // mdit块


### PR DESCRIPTION
改了一下 Callout Aliases 的正则，使其支持折叠。

Callout 折叠语法如下：

```markdown
%% 默认展开 %%
> [!note]+ 标题
> 内容

%% 默认折叠 %%
> [!note]- 标题
> 内容
```

现在的折叠语法如下：

```markdown
%% 默认展开 %%
::: !note+ 标题

内容

:::

%% 默认折叠 %%
::: !note- 标题

内容

:::
```